### PR TITLE
add envirornemt value for backend

### DIFF
--- a/docker-multi-app/docker-compose-dev.yml
+++ b/docker-multi-app/docker-compose-dev.yml
@@ -25,6 +25,12 @@ services:
     volumes:
       - /app/node_modules
       - ./backend:/app
+    environment:
+      MYSQL_ROOT_PASSWORD: johnahn
+      MYSQL_DATABASE: myapp
+      MYSQL_HOST: mysql
+      MYSQL_USER: root
+      MYSQL_PORT: 3306
     
   mysql:
     build: ./mysql


### PR DESCRIPTION
db.js refer environment to connect sql.
but there is no enviroment in docker-compose-dev.yml